### PR TITLE
Create dependency between cluster issuers and cert-manager

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,6 +1,31 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/alekc/kubectl" {
+  version     = "2.0.4"
+  constraints = "2.0.4"
+  hashes = [
+    "h1:1Ence3VDSQ7BNO+IFD6QoGBiBf6rJgCbygkATSdjcTA=",
+    "h1:6xRO3WlBsOTbeJ90QFjxGbc4BjnoGdEaeSCdWI/B1jU=",
+    "h1:TUeUq1UdVkHTxcgq7CJWWXBrc8VEQTufmgU18qDmfGE=",
+    "h1:mCz0lOwNsFCZEcFf7DBSe6b4hZgn5piiy0mZDwRGUIU=",
+    "zh:15c227886bac78c8b8827f85595648212574ec81febc39e1055e1a6bf048fe65",
+    "zh:2211ebeeb0918dbb3587d206e32adca9e1f343a93bbffcd37d8d99bf4d8dea9a",
+    "zh:2303836cdea12ece8dbe39c2d7d30a9378fd06e9c2ebda66cbe5e01cc096ee2e",
+    "zh:3687f69e531c70845682b214888a9959b93f2be3c2531801228a4b1965d59921",
+    "zh:4dd686b4c55e2eedd80464984c9bb736c2df7a96d9dd59a692d91d09173f5f64",
+    "zh:51e29c13a87e56867b4be0b0c68da874149bf6d4014d7259b62d91162142c1bd",
+    "zh:5d9d99260f2adfb8867068a3d7644336d57cfa7710062c5221dcbb5a7ec90c7d",
+    "zh:901c19d73da6688437b19a85e3cd60e8f2090c84699e108b31953bb87f6d3141",
+    "zh:9547743606a36fa6b6748c5e2e1959b6f185730a1da53a3c351cfa0d8c096687",
+    "zh:9772a30704e69b54de5a332858a39591f52286121cffcba702346830b1c6e362",
+    "zh:b44792f99d7c90b9a364dd922f861e459ae1b1edc039f6b3078549021fec4511",
+    "zh:b5eb871ed2e39b9236dce06170b1fd5dda29f3c1d53f8e08285ccb9a4f574201",
+    "zh:e8bb4c3d9f680977b560e9dec24662650f790259b2c1311ee07a72157f6492b3",
+    "zh:f4772cfa0f9c73fdef008bb917cd268620009dc7ff270a4d819125c642b5acce",
+  ]
+}
+
 provider "registry.terraform.io/digitalocean/digitalocean" {
   version     = "2.34.1"
   constraints = "~> 2.0"

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,11 @@ terraform {
       version = "2.12.1"
     }
 
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "2.0.4"
+    }
+
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "2.25.2"
@@ -39,6 +44,15 @@ provider "helm" {
   experiments {
     manifest = true
   }
+}
+
+provider "kubectl" {
+  host  = digitalocean_kubernetes_cluster.this.endpoint
+  token = digitalocean_kubernetes_cluster.this.kube_config[0].token
+  cluster_ca_certificate = base64decode(
+    digitalocean_kubernetes_cluster.this.kube_config[0].cluster_ca_certificate
+  )
+  load_config_file = false
 }
 
 provider "kubernetes" {

--- a/runtime/cert_manager.tf
+++ b/runtime/cert_manager.tf
@@ -19,8 +19,10 @@ resource "helm_release" "cert_manager" {
   }
 }
 
-resource "kubernetes_manifest" "cert_manager_issuer_staging" {
-  manifest = yamldecode(<<-EOT
+resource "kubectl_manifest" "cert_manager_issuer_staging" {
+  depends_on = [helm_release.cert_manager]
+
+  yaml_body = <<-YAML
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer
     metadata:
@@ -34,12 +36,13 @@ resource "kubernetes_manifest" "cert_manager_issuer_staging" {
         solvers:
         - http01:
             ingress: {}
-  EOT
-  )
+  YAML
 }
 
-resource "kubernetes_manifest" "cert_manager_issuer_prod" {
-  manifest = yamldecode(<<-EOT
+resource "kubectl_manifest" "cert_manager_issuer_prod" {
+  depends_on = [helm_release.cert_manager]
+
+  yaml_body = <<-YAML
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer
     metadata:
@@ -53,6 +56,5 @@ resource "kubernetes_manifest" "cert_manager_issuer_prod" {
         solvers:
         - http01:
             ingress: {}
-  EOT
-  )
+  YAML
 }

--- a/runtime/main.tf
+++ b/runtime/main.tf
@@ -10,6 +10,11 @@ terraform {
       version = "2.12.1"
     }
 
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "2.0.4"
+    }
+
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "2.25.2"


### PR DESCRIPTION
- 522317c **fix: create dependency between cluster issuers and cert-manager**

  The cluster issuer resources depend on a customer resource definition
  supplied by the cert-manager chart, but they did not previously depend
  on that chart being created first.
  
  Unfortunately, that alone doesn't allow deployment to happen since the
  `kubernetes_manifest` resource type attempts to validate the resource
  type at plan time, when the CRD is not yet installed. This could only
  be fixed by moving the deployment of resources into a completely
  independent deployment (even a submodule doesn't help).
  
  The `kubectl` provider also provides a "manifest" resource type, which
  does not very the resource types at plan time. Using this instead allows
  planning to complete.
