### PR TITLE
Output cluster ID

### DIFF
--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -42,6 +42,10 @@ variable "kubernetes_default_node_pool_node_count" {
   type = number
 }
 
+output "id" {
+  value = digitalocean_kubernetes_cluster.this.id
+}
+
 output "name" {
   value = digitalocean_kubernetes_cluster.this.name
 }


### PR DESCRIPTION
- f6ceb65 **chore(cluster): output cluster ID**

  This is useful for dependent resources such as database firewall IDs.
